### PR TITLE
Fix undefined variable errors when running playbook with teamcity-server role

### DIFF
--- a/tasks/teamcity-server.yml
+++ b/tasks/teamcity-server.yml
@@ -23,7 +23,7 @@
 
 - name: "Put TeamCity service file (systemd)"
   template:
-    src: "teamcity-agent.service.j2"
+    src: "teamcity-server.service.j2"
     dest: "/lib/systemd/system/teamcity-server.service"
     mode: 0644
   when: "ansible_service_mgr == 'systemd'"

--- a/templates/teamcity-server.service.j2
+++ b/templates/teamcity-server.service.j2
@@ -4,7 +4,7 @@ Description="TeamCity Server"
 
 [Service]
 Type=forking
-User={{ teamcity_server_user_name }}
+User={{ teamcity_server_user }}
 PIDFile={{ teamcity_server_dir }}/logs/teamcity-server.pid
 ExecStart={{ teamcity_server_dir }}/bin/teamcity-server.sh start
 ExecStop={{ teamcity_server_dir }}/bin/teamcity-server.sh stop


### PR DESCRIPTION
Hi,

when I ran a very simple playbook using your role, I received two `AnsibleUndefinedVariable `errors, namely for one variable in the `teamcity-server.service.j2` template, where `teamcity_server_user` should have been used instead of `teamcity_server_user_name`, and another in `tasks/teamcity-server.yml`, where the template was referenced with `agent` instead of `server` in its name.

Otherwise thanks for the effort of putting together this role!