### PR TITLE
Update to support auth token format in 2018.1

### DIFF
--- a/tasks/teamcity-server.yml
+++ b/tasks/teamcity-server.yml
@@ -109,7 +109,7 @@
     mode: 0644
 
 - name: "Get Authentication Token"
-  shell: "grep -ioE 'Super user authentication token: \"(.*)\"' {{ teamcity_server_dir }}/logs/teamcity-server.log | tail -1 | cut -f2 -d'\"'"
+  shell: "grep -ioE 'Super user authentication token: (.*)' {{ teamcity_server_dir }}/logs/teamcity-server.log | tail -1 | sed 's/.*token:[ \"]*\([a-zA-Z0-9]*\).*/\1/'
   register: _token
   check_mode: no
   args:

--- a/tasks/teamcity-server.yml
+++ b/tasks/teamcity-server.yml
@@ -109,7 +109,7 @@
     mode: 0644
 
 - name: "Get Authentication Token"
-  shell: "grep -ioE 'Super user authentication token: (.*)' {{ teamcity_server_dir }}/logs/teamcity-server.log | tail -1 | sed 's/.*token:[ \"]*\([a-zA-Z0-9]*\).*/\1/'
+  shell: "grep -ioE 'Super user authentication token: (.*)' {{ teamcity_server_dir }}/logs/teamcity-server.log | tail -1 | sed 's/.*token:[ \\\"]*\\([a-zA-Z0-9]*\\).*/\\1/'"
   register: _token
   check_mode: no
   args:


### PR DESCRIPTION
I attempted to install TC "2018.1" using these settings:

teamcity_server_version: "2018.1"
teamcity_server_sha256: "d16ec0a4693cf4203d5e201cedf00e7a1559efaec98f54d018e67a3a17ad893d"

The role was failing when on the "Create Admin User" step and I traced it to not having the proper auth token. From the logs I could see that the auth token in 2018.1 does not have double-quotes around it so the grep and cut were not working. I updated the auth token extraction step to support the new format. I have not tried this on an earlier TC build but I did locally test adding double-quotes on both sides of the token.